### PR TITLE
Auth related components accept an optional publicURL prop for redirecting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2024-03-13
+
+### Added
+
+- [RequireAuth] Now PUBLIC_URL is a prop, with fallback to process.env.PUBLIC_URL
+
 ## [1.2.1] - 2024-02-22
 
 ### Added
@@ -150,7 +156,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Empty SideMenu
 - Issue template
 
-[unreleased]: https://github.com/CinCoders/cinnamon/compare/version/v1.2.1...develop
+[unreleased]: https://github.com/CinCoders/cinnamon/compare/version/v1.3.0...develop
+[1.3.0]: https://github.com/CinCoders/cinnamon/compare/version/v1.2.1...version/v1.3.0
 [1.2.1]: https://github.com/CinCoders/cinnamon/compare/version/v1.2.0...version/v1.2.1
 [1.2.0]: https://github.com/CinCoders/cinnamon/compare/version/v1.1.0...version/v1.2.0
 [1.1.0]: https://github.com/CinCoders/cinnamon/compare/version/v1.0.3...version/v1.1.0

--- a/docs/USAGE.MD
+++ b/docs/USAGE.MD
@@ -180,15 +180,15 @@ A base page component with authentication using keycloak.
 | **haveToast**           | Boolean     | No       | none                  | Enable the usage of a custom toast from cinnamon package, inside the page component                   |
 | **createNavbarContext** | Boolean     | Yes      | none                  | Enable the usage of custom hook useNavbar, to change navbar props dinamically                         |
 | **components**          | Object      | No       | none                  | An object that accepts a custom navbar, footer or toastContainer to override these default components |
-| **auth**                | Object      | Yes      | none                  | An object that accepts a keycloak instance, initialized flag and roles to have access                 |
+| **auth**                | Object      | Yes      | none                  | An object that accepts an authContext, publicURL and roles to have access                 |
 
 ### Interface of props
 
 ```typescript
 interface PageWithAuthProps extends PageProps {
-  auth: {
-    keycloak: Keycloak;
-    initialized: boolean;
+  authProps: {
+    auth: AuthContextProps;
+    publicURL?: string;
     permittedRoles: string[];
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cincoders/cinnamon",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cincoders/cinnamon",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cincoders/cinnamon",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "A collection components for standardized system appearance and functionality, easing development in web applications.",
   "license": "MIT",
   "author": "CInCoders <cincoders@cin.ufpe.br> (https://cincoders.cin.ufpe.br)",

--- a/src/lib-components/ForbiddenPage/index.tsx
+++ b/src/lib-components/ForbiddenPage/index.tsx
@@ -14,6 +14,7 @@ import {
 
 export interface ForbiddenPageProps {
   auth?: AuthContextProps;
+  publicURL?: string;
 }
 
 interface Location {
@@ -25,8 +26,9 @@ interface Location {
   };
 }
 
-export const ForbiddenPage = ({ auth }: ForbiddenPageProps) => {
+export const ForbiddenPage = ({ auth, publicURL: propPublicURL }: ForbiddenPageProps) => {
   const email = auth?.user?.profile.email;
+  const publicURL = propPublicURL || process.env.PUBLIC_URL;
   const [from, setFrom] = useState<string>();
   const navigate = useNavigate();
   const location = useLocation() as Location;
@@ -34,7 +36,7 @@ export const ForbiddenPage = ({ auth }: ForbiddenPageProps) => {
     if (location.state?.from !== undefined) {
       setFrom(location.state.from.pathname);
     } else {
-      navigate(process.env.PUBLIC_URL as To);
+      navigate(publicURL as To);
     }
   }, []);
 

--- a/src/lib-components/ForbiddenPage/index.tsx
+++ b/src/lib-components/ForbiddenPage/index.tsx
@@ -26,9 +26,9 @@ interface Location {
   };
 }
 
-export const ForbiddenPage = ({ auth, publicURL: propPublicURL }: ForbiddenPageProps) => {
+export const ForbiddenPage = ({ auth, publicURL }: ForbiddenPageProps) => {
   const email = auth?.user?.profile.email;
-  const publicURL = propPublicURL || process.env.PUBLIC_URL;
+  const baseURL = publicURL ?? process.env.PUBLIC_URL;
   const [from, setFrom] = useState<string>();
   const navigate = useNavigate();
   const location = useLocation() as Location;
@@ -36,7 +36,7 @@ export const ForbiddenPage = ({ auth, publicURL: propPublicURL }: ForbiddenPageP
     if (location.state?.from !== undefined) {
       setFrom(location.state.from.pathname);
     } else {
-      navigate(publicURL as To);
+      navigate(baseURL as To);
     }
   }, []);
 

--- a/src/lib-components/PageWithAuth/index.tsx
+++ b/src/lib-components/PageWithAuth/index.tsx
@@ -5,6 +5,7 @@ import { AuthContextProps } from 'react-oidc-context';
 interface PageWithAuthProps extends PageProps {
   authProps: {
     auth: AuthContextProps;
+    publicURL?: string;
     permittedRoles: string[];
   };
 }
@@ -21,7 +22,7 @@ export function PageWithAuth({
 }: PageWithAuthProps) {
   const { auth, permittedRoles } = authProps;
   return (
-    <RequireAuth auth={auth} permittedRoles={permittedRoles}>
+    <RequireAuth auth={auth} permittedRoles={permittedRoles} publicURL={authProps.publicURL}>
       <Page
         navbar={navbar}
         footer={footer}

--- a/src/lib-components/RequireAuth/index.tsx
+++ b/src/lib-components/RequireAuth/index.tsx
@@ -8,10 +8,13 @@ import { KeycloakPayload, jwtDecode } from '@/utils/authUtils';
 interface AuthProps {
   auth: AuthContextProps;
   permittedRoles: string[];
+  publicURL?: string;
   children: JSX.Element;
 }
 
 export const RequireAuth = (props: AuthProps): React.ReactElement => {
+  const publicURL = props.publicURL || process.env.PUBLIC_URL;
+
   const location = useLocation();
   const { children, auth, permittedRoles } = props;
   const [waiting, setWaiting] = useState(true);
@@ -84,7 +87,7 @@ export const RequireAuth = (props: AuthProps): React.ReactElement => {
   if (auth.isAuthenticated) {
     return (
       <Navigate
-        to={`${process.env.PUBLIC_URL}/forbidden`}
+        to={`${publicURL}/forbidden`}
         replace
         state={{ from: location }}
       />

--- a/src/lib-components/RequireAuth/index.tsx
+++ b/src/lib-components/RequireAuth/index.tsx
@@ -13,7 +13,7 @@ interface AuthProps {
 }
 
 export const RequireAuth = (props: AuthProps): React.ReactElement => {
-  const publicURL = props.publicURL || process.env.PUBLIC_URL;
+  const publicURL = props.publicURL ?? process.env.PUBLIC_URL;
 
   const location = useLocation();
   const { children, auth, permittedRoles } = props;


### PR DESCRIPTION
PageWithAuth, ForbiddenPage and RequireAuth accepts an optional prop publicURL, used for redirecting. As a fallback, process.env.PUBLIC_URL will be used.